### PR TITLE
Fixing tutorial for Ubuntu 20.04

### DIFF
--- a/tests/test_int.py
+++ b/tests/test_int.py
@@ -25,6 +25,7 @@ class TestBase(LiveServerTestCase):
 
         chrome_options = webdriver.chrome.options.Options()
         chrome_options.add_argument('--headless')
+        chrome_options.add_argument('--remote-debugging-port=9222')
 
         self.driver = webdriver.Chrome(options=chrome_options)
 


### PR DESCRIPTION
I've fixed the problem that caused the tests to fail when running them on an Ubuntu 20.04 LTS machine as per the suggestion in [this thread](https://bugs.chromium.org/p/chromedriver/issues/detail?id=3665&q=ubuntu%2020.04&can=1).

All that needed doing was to add the `--remote-debugging-port=9222` option to `chrome_options`.

Now @OliverNichols, if you're reading this: hi! Hope you're doing well! We all miss you at QA! You're no doubt extremely busy, but if you see this and get the chance, dya think you could merge this in for me? Furthermore, dya think you could pass ownership rights to me for the repo please?

Thank you!